### PR TITLE
Check blocked words against alphabet case-insensitively

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,13 +51,14 @@ export default class Sqids {
 		// 2. no words less than 3 chars
 		// 3. if some words contain chars that are not in the alphabet, remove those
 		const filteredBlocklist = new Set<string>();
-		const alphabetChars = alphabet.split('');
+		const alphabetChars = alphabet.toLowerCase().split('');
 		for (const word of blocklist) {
 			if (word.length >= 3) {
-				const wordChars = word.split('');
+				const wordLowercased = word.toLowerCase();
+				const wordChars = wordLowercased.split('');
 				const intersection = wordChars.filter((c) => alphabetChars.includes(c));
 				if (intersection.length == wordChars.length) {
-					filteredBlocklist.add(word.toLowerCase());
+					filteredBlocklist.add(wordLowercased);
 				}
 			}
 		}


### PR DESCRIPTION
The blocklist should be treated case-insensitively. But currently, if you have this alphabet (all uppercase letters):
```
ABCDEFGHIJKLMNOPQRSTUVWXYZ
```
The logic for cleaning up the blocklist in the constructor will remove the entire blocklist:
https://github.com/sqids/sqids-spec/blob/2127f4d6002eb780944bc175b1a8fd3385838cd0/src/index.ts#L49-L63

Because of this part specifically:
https://github.com/sqids/sqids-spec/blob/2127f4d6002eb780944bc175b1a8fd3385838cd0/src/index.ts#L58

Which does case-sensitive comparisons.

This means you could end up with IDs that contains profanity, e.g. `FUCK`, `BITCH`, `SEXY`, etc.

I haven't added tests yet because first I want this to be confirmed.